### PR TITLE
Content: Use cases section

### DIFF
--- a/content/resources/use-cases/_index.md
+++ b/content/resources/use-cases/_index.md
@@ -1,5 +1,16 @@
 ---
-title: Use cases for Ecoacoustics
+title: Use Cases for Ecoacoustics
 ---
 
-Introduction and background. 
+Open Ecoacoustics has a vision to "enable open science and conservation through
+the development and promotion of open access ecoacoustics technologies,
+methodologies and standards".  Biodiversity inventories and monitoring in
+Australia are difficult due to the vast areas of remote areas few people visit
+which are confounded by some species which are exceedingly difficult to detect.
+Imagine a 10 to 20 fold decrease in the time required in the field to generate
+verifiable occurrence data for species which vocalise, perhaps only
+occasionally. While this is clearly a huge challenge, the tools and workflows
+being developed, and showcased by Open Ecoacoustics, are demonstrating how this
+can be achieved. In this section of the website, we aim to showcase how
+ecoacoustic data can be a game changer for our understanding of species
+distributions.

--- a/content/resources/use-cases/_index.md
+++ b/content/resources/use-cases/_index.md
@@ -2,15 +2,7 @@
 title: Use Cases for Ecoacoustics
 ---
 
-Open Ecoacoustics has a vision to "enable open science and conservation through
-the development and promotion of open access ecoacoustics technologies,
-methodologies and standards". Biodiversity inventories and monitoring in
-Australia are difficult due to the vast and remote areas that few people visit,
-and is further confounded by some species which are exceedingly difficult to
-detect. Now image a 10 to 20 fold decrease in the time required in the field to
-generate verifiable occurrence data for species which vocalise, perhaps only
-occasionally, across vast temporal and spatial scales. The potential value that
-this kind of data holds is clear. So, this section of the website is where we
-aim to showcase how ecoacoustic data can be a game changer for our understanding
-of species distributions, by harnessing analysis methods that have typically
-been used with data collected by traditional survey techniques.
+This section of the website is where we aim to showcase how ecoacoustic data can
+be a game changer for our understanding of ecosystems and patterns of
+biodiversity, by harnessing analysis methods that have typically been used with
+data collected by traditional survey techniques.

--- a/content/resources/use-cases/_index.md
+++ b/content/resources/use-cases/_index.md
@@ -1,0 +1,5 @@
+---
+title: Use cases for Ecoacoustics
+---
+
+Introduction and background. 

--- a/content/resources/use-cases/_index.md
+++ b/content/resources/use-cases/_index.md
@@ -4,13 +4,13 @@ title: Use Cases for Ecoacoustics
 
 Open Ecoacoustics has a vision to "enable open science and conservation through
 the development and promotion of open access ecoacoustics technologies,
-methodologies and standards".  Biodiversity inventories and monitoring in
-Australia are difficult due to the vast areas of remote areas few people visit
-which are confounded by some species which are exceedingly difficult to detect.
-Imagine a 10 to 20 fold decrease in the time required in the field to generate
-verifiable occurrence data for species which vocalise, perhaps only
-occasionally. While this is clearly a huge challenge, the tools and workflows
-being developed, and showcased by Open Ecoacoustics, are demonstrating how this
-can be achieved. In this section of the website, we aim to showcase how
-ecoacoustic data can be a game changer for our understanding of species
-distributions.
+methodologies and standards". Biodiversity inventories and monitoring in
+Australia are difficult due to the vast and remote areas that few people visit,
+and is further confounded by some species which are exceedingly difficult to
+detect. Now image a 10 to 20 fold decrease in the time required in the field to
+generate verifiable occurrence data for species which vocalise, perhaps only
+occasionally, across vast temporal and spatial scales. The potential value that
+this kind of data holds is clear. So, this section of the website is where we
+aim to showcase how ecoacoustic data can be a game changer for our understanding
+of species distributions, by harnessing analysis methods that have typically
+been used with data collected by traditional survey techniques.

--- a/content/resources/use-cases/gdm/GDM_fig1.jpg
+++ b/content/resources/use-cases/gdm/GDM_fig1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a6e6c54a77e617caf12e84e4b0ebe4ad5c3fae3add3a916fe59b0339c4e7e61
+size 457709

--- a/content/resources/use-cases/gdm/GDM_fig2.png
+++ b/content/resources/use-cases/gdm/GDM_fig2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40499563b5df346c8ed6835494cf62ca9bc797f69ff44b2498a7c71cea4dd1bb
+size 38011

--- a/content/resources/use-cases/gdm/index.md
+++ b/content/resources/use-cases/gdm/index.md
@@ -1,4 +1,166 @@
 ---
-title: GDM
+title: Generalised Dissimilarity Modeling
 weight: 2
 ---
+
+## Summary
+
+Understanding changes in species composition across temporal and spatial
+scales can provide important insights for management and conservation of
+biodiversity, particularly with increasing threats due to climate change and
+land clearing. Traditionally, species community surveys, performed with
+consistent methodology, are used to model compositional dissimilarity. However,
+the aim of this project was to demonstrate how data collected by passive
+acoustic monitoring (PAM) may also be used to examine spatial variation in
+species composition across a landscape.
+
+This case study uses annotated acoustic data from a previously published study
+([Doohan et al. 2019](https://www.sciencedirect.com/science/article/pii/S2351989419303919)), to
+demonstrate how acoustic data, and the analytical tools coming soon to
+EcoCommons (an [R package](https://github.com/EcoCommons-Australia/community-modelling) to help
+you understand how to set up a GDM model is now available), can be used to model
+changes in avian species composition within the Mulga Lands bioregion of
+Queensland. The advantages of PAM include reduced observer bias, consistency in
+survey effort, and is feasibly scalable across both time and space.
+
+The R code used to generate these results is provided.
+
+## Introduction
+
+Faunal biodiversity is known to be influenced by vegetation condition,
+structure and diversity. Given the history and extent of vegetation clearing
+across Australia, it is essential that the relationships between vegetation and
+faunal biodiversity are understood. The Mulga Lands bioregion, which stretches
+from south western Queensland into northern New South Wales, is one such area
+that has experienced high levels of vegetation clearance. This region provides a
+unique habitat for many arid, semi-arid and temperate species. However, the
+effects of regrowth vegetation on community composition is poorly understood,
+particularly in semi-arid and arid environments. Birds are often sensitive to
+the effects of landscape modification and clearing, and therefore represent good
+candidate species to study the effects of regrowth vegetation. As a result,
+avian biodiversity was examined in the Mulga Lands bioregion, in relation to
+various stages of vegetation growth.
+
+This research involved the use of passive acoustic monitoring devices, which can
+capture large scale datasets on environmental soundscapes. Analysis of those
+soundscapes represents the focus of the emerging field of ecoacoustics. The
+increasing use of passive acoustic monitoring represents an ever-growing body of
+data which can be harnessed to answer an array of ecological questions (e.g.
+A2O, ecosounds etc). We therefore intend to demonstrate how this data is also an
+ideal candidate to be used to examine compositional turnover of species across
+various spatial scales, which has traditionally been performed with presence
+absence field survey data. The advantage of this workflow is being able to
+leverage existing acoustic datasets that may already contain species
+annotations. This data, accompanied by either study site survey data, or remote
+sensing spatial layers, will be able to provide key insights into environmental
+predictors of biological diversity across various spatial and temporal scales.
+
+## Methods
+
+The data used in this case study consisted of avian species identifications from
+acoustic recordings obtained from a previous study undertaken by Doohan et al.
+(2019). Their study took place in the Bowra Wildlife Sanctuary, an Australian
+Wildlife Conservancy property approximately 850km west of Brisbane, Australia.
+The data came from nine study sites in total, which were classified based on
+their time since clearing occurred, representing three regrowth sites (cleared
+within the last 15 years; site code NR), three intermediate regrowth sites
+(cleared between 15 and 30 years; site code IR) and three old growth sites (no
+clearing events within the last 30 years; site code OG and OM)(Figure 1). One
+acoustic monitoring device was deployed at each site (model SM3; Wildlife
+Acoustics), and set to record the dawn chorus each day continuously for 3 hours
+(recorded as WAV format, in mono at a sample rate of 22,050 Hz)  during the
+study period of 28 days (29th August 2017 -- 25th September 2017). From this
+data, 45 hours of audio were processed by [Doohan et al. (2019)](https://www.sciencedirect.com/science/article/pii/S2351989419303919)
+using a stratified hierarchical approach, representing 15 randomly selected
+days, and all bird species were manually identified from their calls and
+annotated on the [Ecosounds](https://www.ecosounds.org/) website (project:
+"Cunnamulla").
+
+Figure 1 Study site locations represented by pins (yellow: new regrowth, green:
+intermediate regrowth, red: old growth). Inset map of Australia indicates
+location of the study area.
+
+For the current project, we demonstrate how an existing annotated acoustic
+dataset, along with study site environmental data, can be used to model
+compositional dissimilarity of avian species in relation to various
+environmental predictors. Therefore, a generalised dissimilarity model (GDM)
+approach was chosen. The benefit of this method is that it can statistically
+relate beta diversity to environmental gradients, while accounting for two
+important nonlinearities present in more traditional ecological methods (see
+Ferrier et al., 2007).
+
+Using the GDM package in R (function: GDM with default parameters), a model was
+fit using a range of environmental variables that were collected in the field at
+the location of each acoustic sensor. Vegetation assessments were undertaken by
+[Doohan et al.
+(2019)](https://www.sciencedirect.com/science/article/pii/S2351989419303919) in
+March 2018, using the line intercept method.
+
+The final variables included in the model were:
+
+- Tree height (m)
+- Tree cover (%)
+- Diameter at breast height (DBH, cm)
+- Shrub height (m)
+- Distance to nearest water course (QLD Waterways spatial dataset, m)
+- Geographic distance (between sites, m)
+
+A model using raster layer Soil Adjusted Vegetation Index (SAVI) from Sentinel
+Hub was also performed, but discontinued due to its low explanatory power
+(percent deviance explained = 2.001).
+
+## Results
+
+The model had a percent deviance explained of 27.159, representing the variation
+in observed dissimilarities explained by the model. A slight positive linear
+relationship was seen, whereby as the predicted ecological distance between
+sites increased (predictors), so too did observed compositional dissimilarity
+(Figure 2). Of the environmental predictors, the sum of I-spline coefficients
+was highest for the predictor value tree cover, indicating the greatest effect
+on compositional dissimilarity. It was seen by the gradient of the slope that
+changes between 0 to 30% tree cover resulted in the greatest changes in
+predicted dissimilarity between study site pairs (Figure 2). However, a
+permutation assessment showed that the model was not statistically significant
+(p = 0.370). The intercept of the model was 0.206, which represents the expected
+dissimilarity between sites when the environmental predictors are equal.
+
+Figure 2 Main output plots of the GDM. A: observed compositional dissimilarity
+as a function of predicted ecological distance, where each point represents a
+site pair, and the line represents the GDM-predicted dissimilarity. B: Observed
+compositional dissimilarity as a function of predicted compositional
+dissimilarity, where the line represents a line of equality. C -- F: Plotted GDM
+spline functions for each environmental predictor variable.
+
+Figure 2 Main output plots of the GDM. A: observed compositional dissimilarity
+as a function of predicted ecological distance, where each point represents a
+site pair, and the line represents the GDM-predicted dissimilarity. B: Observed
+compositional dissimilarity as a function of predicted compositional
+dissimilarity, where the line represents a line of equality. C -- F: Plotted GDM
+spline functions for each environmental predictor variable.
+
+## Discussion
+
+These results successfully demonstrate a simple workflow in which acoustic
+datasets can be leveraged to provide insight into patterns of biodiversity
+change relative to environmental predictors. In this case, the original sampling
+design could have limited the model's ability to predict changes in composition
+throughout the landscape relative to the environmental predictors. For example,
+all sensors were located inside a patch of vegetation at least 150 m or greater
+in diameter. The total number of sample sites was also small, and sensors were
+positioned across a relatively small spatial. Nevertheless, this is a great
+example workflow of how annotated acoustic data can be used to perform more
+robust modelling methods, such as GDM.
+
+In this example, study site vegetation survey data was available at the location
+of each recorder. However, it is also possible to use spatially complete gridded
+environmental data with the GDM package, such as remotely sensed data in raster
+format. This allows projection of the model across the spatial grid, to map
+predicted patterns of dissimilarity.
+
+With the growing body of acoustic data, coupled with remotely sensed data or
+ground-survey metadata, it will be possible to examine patterns of biodiversity
+variation across large spatial and temporal scales. Identifying environmental
+factors that are important drivers for species occurrences can help to guide
+land management and landscape rehabilitation / restoration guidelines etc. Can
+also make predictions about compositional turnover related to changes in
+environmental conditions, such as land cover, or temperature (climate change).**

--- a/content/resources/use-cases/gdm/index.md
+++ b/content/resources/use-cases/gdm/index.md
@@ -1,5 +1,5 @@
 ---
-title: Generalised Dissimilarity Modeling
+title:  Harnessing acoustic data and Generalised Dissimilarity Modelling to examine compositional turnover of avian species.
 weight: 2
 ---
 
@@ -46,14 +46,16 @@ capture large scale datasets on environmental soundscapes. Analysis of those
 soundscapes represents the focus of the emerging field of ecoacoustics. The
 increasing use of passive acoustic monitoring represents an ever-growing body of
 data which can be harnessed to answer an array of ecological questions (e.g.
-A2O, ecosounds etc). We therefore intend to demonstrate how this data is also an
-ideal candidate to be used to examine compositional turnover of species across
-various spatial scales, which has traditionally been performed with presence
-absence field survey data. The advantage of this workflow is being able to
-leverage existing acoustic datasets that may already contain species
-annotations. This data, accompanied by either study site survey data, or remote
-sensing spatial layers, will be able to provide key insights into environmental
-predictors of biological diversity across various spatial and temporal scales.
+[A2O](https://acousticobservatory.org/),
+[ecosounds](https://www.ecosounds.org/)). We therefore intend to demonstrate how
+this data is also an ideal candidate to be used to examine compositional
+turnover of species across various spatial scales, which has traditionally been
+performed with presence absence field survey data. The advantage of this
+workflow is being able to leverage existing acoustic datasets that may already
+contain species annotations. This data, accompanied by either study site survey
+data, or remote sensing spatial layers, will be able to provide key insights
+into environmental predictors of biological diversity across various spatial and
+temporal scales.
 
 ## Methods
 
@@ -65,7 +67,7 @@ The data came from nine study sites in total, which were classified based on
 their time since clearing occurred, representing three regrowth sites (cleared
 within the last 15 years; site code NR), three intermediate regrowth sites
 (cleared between 15 and 30 years; site code IR) and three old growth sites (no
-clearing events within the last 30 years; site code OG and OM)(Figure 1). One
+clearing events within the last 30 years; site code OG and OM) (Figure 1). One
 acoustic monitoring device was deployed at each site (model SM3; Wildlife
 Acoustics), and set to record the dawn chorus each day continuously for 3 hours
 (recorded as WAV format, in mono at a sample rate of 22,050 Hz)  during the
@@ -76,9 +78,7 @@ days, and all bird species were manually identified from their calls and
 annotated on the [Ecosounds](https://www.ecosounds.org/) website (project:
 "Cunnamulla").
 
-Figure 1 Study site locations represented by pins (yellow: new regrowth, green:
-intermediate regrowth, red: old growth). Inset map of Australia indicates
-location of the study area.
+{{% figure src="./GDM_fig1.jpg" caption="Figure 1: Study site locations represented by pins (yellow: new regrowth, green: intermediate regrowth, red: old growth). Inset map of Australia indicates location of the study area." width="100%"%}}
 
 For the current project, we demonstrate how an existing annotated acoustic
 dataset, along with study site environmental data, can be used to model
@@ -92,8 +92,7 @@ Ferrier et al., 2007).
 Using the GDM package in R (function: GDM with default parameters), a model was
 fit using a range of environmental variables that were collected in the field at
 the location of each acoustic sensor. Vegetation assessments were undertaken by
-[Doohan et al.
-(2019)](https://www.sciencedirect.com/science/article/pii/S2351989419303919) in
+[Doohan et al. (2019)](https://www.sciencedirect.com/science/article/pii/S2351989419303919) in
 March 2018, using the line intercept method.
 
 The final variables included in the model were:
@@ -124,19 +123,7 @@ permutation assessment showed that the model was not statistically significant
 (p = 0.370). The intercept of the model was 0.206, which represents the expected
 dissimilarity between sites when the environmental predictors are equal.
 
-Figure 2 Main output plots of the GDM. A: observed compositional dissimilarity
-as a function of predicted ecological distance, where each point represents a
-site pair, and the line represents the GDM-predicted dissimilarity. B: Observed
-compositional dissimilarity as a function of predicted compositional
-dissimilarity, where the line represents a line of equality. C -- F: Plotted GDM
-spline functions for each environmental predictor variable.
-
-Figure 2 Main output plots of the GDM. A: observed compositional dissimilarity
-as a function of predicted ecological distance, where each point represents a
-site pair, and the line represents the GDM-predicted dissimilarity. B: Observed
-compositional dissimilarity as a function of predicted compositional
-dissimilarity, where the line represents a line of equality. C -- F: Plotted GDM
-spline functions for each environmental predictor variable.
+{{% figure src="./GDM_fig2.png" caption="Figure 2: Main output plots of the GDM. A: observed compositional dissimilarity as a function of predicted ecological distance, where each point represents a site pair, and the line represents the GDM-predicted dissimilarity. B: Observed compositional dissimilarity as a function of predicted compositional dissimilarity, where the line represents a line of equality. C -- F: Plotted GDM spline functions for each environmental predictor variable." width="100%"%}}
 
 ## Discussion
 
@@ -161,6 +148,7 @@ With the growing body of acoustic data, coupled with remotely sensed data or
 ground-survey metadata, it will be possible to examine patterns of biodiversity
 variation across large spatial and temporal scales. Identifying environmental
 factors that are important drivers for species occurrences can help to guide
-land management and landscape rehabilitation / restoration guidelines etc. Can
-also make predictions about compositional turnover related to changes in
-environmental conditions, such as land cover, or temperature (climate change).**
+land management, landscape rehabilitation and inform restoration guidelines. It
+is also possible to make predictions about compositional turnover related to
+changes in environmental conditions, such as land cover, or temperature (climate
+change).

--- a/content/resources/use-cases/gdm/index.md
+++ b/content/resources/use-cases/gdm/index.md
@@ -3,6 +3,8 @@ title:  Harnessing acoustic data and Generalised Dissimilarity Modelling to exam
 weight: 2
 ---
 
+By [Dr Andrew Schwenke](https://orcid.org/0000-0002-5281-0115)
+
 ## Summary
 
 Understanding changes in species composition across temporal and spatial
@@ -152,3 +154,20 @@ land management, landscape rehabilitation and inform restoration guidelines. It
 is also possible to make predictions about compositional turnover related to
 changes in environmental conditions, such as land cover, or temperature (climate
 change).
+
+## Acknowledgements
+
+- I would like to first acknowledge the authors of the original publication from
+  which this data was sourced: Brendan Doohan, Jeanette Kemp, and Susan Fuller.
+  The article was published Global Ecology and Conservation (2019), and is
+  available [here](https://doi.org/10.1016/j.gecco.2019.e00798).
+  - This project was internally funded by the Queensland University of Technology.
+  - We thank the Australian Wildlife Conservancy for site access, previous species records and facilitation of the project.
+  - Prof. Paul Roe for the loan of additional sensors.
+  - The [Ecosounds platform](https://www.ecosounds.org/), for management,
+    access, visualisation, and analysis of the acoustic data used in this project.
+- The [EcoCommons](https://www.ecocommons.org.au/) platform:
+  - Read more about ecoacoustic integration with EcoCommons [here](https://www.ecocommons.org.au/acoustic-use-case/).
+  - See the new [community modelling (GDM) R package](https://github.com/EcoCommons-Australia/community-modelling) by EcoCommons.
+  - Visit the [Educational Material](https://www.ecocommons.org.au/educational-material/) section to learn more
+    about the platform.

--- a/content/resources/use-cases/gdm/index.md
+++ b/content/resources/use-cases/gdm/index.md
@@ -1,0 +1,4 @@
+---
+title: GDM
+weight: 2
+---

--- a/content/resources/use-cases/sdm/boobook_frequency.png
+++ b/content/resources/use-cases/sdm/boobook_frequency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e75dd3b590c6146ec73050eb0605c7425fda0cb1b1790c6a8d5a8b3b011d6130
+size 94327

--- a/content/resources/use-cases/sdm/gg_powl_maxent_stack1_prediction.png
+++ b/content/resources/use-cases/sdm/gg_powl_maxent_stack1_prediction.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b4d1083484fe0bb11ff6243cea377e904120f1a7229864f79aab25018531bd6
+size 330204

--- a/content/resources/use-cases/sdm/hoot_detective.png
+++ b/content/resources/use-cases/sdm/hoot_detective.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2402f136e3edbaa7b1493ab08cb3914248cfcab9b33cd5c7be3ad83e22d496b
+size 940194

--- a/content/resources/use-cases/sdm/hoot_segments_per_day.png
+++ b/content/resources/use-cases/sdm/hoot_segments_per_day.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b194f340cc0868ceb1be5fc469b940f7069d3a937835586df1942b12682f40a1
+size 9084

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -10,21 +10,19 @@ By Dr Andrew Schwenke & Dr Rob Clemens
 The Australian Acoustic Observatory (A2O) is a continental-scale acoustic sensor
 network that provides data for hundreds of acoustic sensors across seven
 Australian ecoregions. This data is freely available to researchers, citizen
-scientists, and the general public, for use under [CC BY
-4.0](https://creativecommons.org/licenses/by/4.0/) licence. More information
-about the A2O can be found in a paper published in [Methods in Ecology and
-Evolution (Roe at al.,
-2021)](https://acousticobservatory.org/wp-content/uploads/2021/07/A2O_Methods-in-Ecology-and-Evolution_2021.pdf).
+scientists, and the general public, for use under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) licence. More information
+about the A2O can be found in a paper published in [Methods in Ecology and Evolution (Roe at al., 2021)](https://acousticobservatory.org/wp-content/uploads/2021/07/A2O_Methods-in-Ecology-and-Evolution_2021.pdf).
 For National Science Week in 2021, a partnership between ABC Science, the
 Australian Acoustic Observatory, Queensland University of Technology and the
-University of New England, formed the Hoot Detective project. This was a citizen
-science project that used recordings from the Australian Acoustic Observatory,
-resulting in the identification of 23,568 owl calls by members of the public.
-There are a variety of advantages to this kind of continental scale data
-([Guerin et al.
-2020](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecs2.3307))
+University of New England, formed the Hoot Detective project (Figure 1). This
+was a citizen science project that used recordings from the Australian Acoustic
+Observatory, resulting in the identification of 23,568 owl calls by members of
+the public. There are a variety of advantages to this kind of continental scale
+data ([Guerin et al. 2020](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecs2.3307))
 and those advantages directly apply to questions looking to predict a species
 distribution.
+
+{{% figure src="./hoot_detective.png" caption="Figure 1: Hoot Detective website." width="50%"%}}
 
 First, occurrence data for most fauna in Australia are not systematically
 collected at geographic scales. Most data for species that vocalise are highly
@@ -89,26 +87,27 @@ of annotations for five owl species: Masked Owl (Tyto novaehollandiae), Eastern
 Barn Owl (Tyto javanica), Barking Owl (Ninox connivens), Powerful Owl (Ninox
 strenua), and Southern Boobook (Ninox boobook). All data, including audio
 recordings, annotations, and associated sensor metadata, is available for
-download and use from the [A2O data
-portal](https://acousticobservatory.org/data/find-data/). A GitHub repository
+download and use from the [A2O data portal](https://acousticobservatory.org/data/find-data/). A GitHub repository
 detailing the complete methods for preparing the Hoot Detective data, prediction
 layers, and running preliminary SDM analyses with R is
-[available](https://github.com/andrew-1234/sdm-usecase-master).
+[also provided](https://github.com/andrew-1234/sdm-usecase-master).
 
 ### Data preparation
 
 The Hoot Detective project resulted in 28723 segments of annotated audio, from
 37 sensors. Each segment of audio was 10 seconds in length, resulting in a total
 of just under 80 hours of annotated audio. Audio segments came from most days
-spanning between June, 2019, until July, 2021 (Figure XX). These annotations
+spanning between June, 2019, until July, 2021 (Figure 2). These annotations
 were summarised in R to get occurrence data for each species, which included
 determining if at any point the target species was recorded (presence) or was
-absent from recordings (absence). 
+absent from recordings (absence).
+
+{{% figure src="./hoot_segments_per_day.png" caption="Figure 2: Histogram demonstrating total frequency of annotated audio segments per day in the Hoot Detective data set." width="100%"%}}
 
 A Powerful Owl presence was recorded in Western Australia, which is quite far
 outside of the recognised distribution. Therefore, Powerful Owl records were
 filtered further, using a buffered boundary of the known distribution extent
-derived from ALA records (?), to remove these potentially anomalous records. 
+derived from ALA records, to remove these potentially anomalous records. 
 
 The A2O uses a paired sensor design, with four sensors per site. The distance
 between sensors is typically within 500m to 5000m. Therefore, we first attempted
@@ -130,8 +129,7 @@ masked to the buffered boundary extent representing the known distribution. 
 
 Powerful Owl presence data were used to extract environmental variable values
 from eastern Australia, and the resulting presence data and environmental
-rasters were used in a Maxent model in R ([see
-code](https://github.com/andrew-1234/sdm-usecase-master)).
+rasters were used in a Maxent model in R ([see code](https://github.com/andrew-1234/sdm-usecase-master)).
 
 Presence only vs presence absence comparisons were made within the EcoCommons
 platform. Evironmental predictors were at 1 km resolution and included the ANU
@@ -146,8 +144,7 @@ selected the Southern Boobook which was recorded at all but one station (mean
 137 vocalisations, range 0 to 993). We then extracted raster grid values from
 the two forest area variables, bioclim variables 5,6 and 17, and NVIS, a
 national vegetation classification. We then ran a Boosted regression tree (BRT)
-model specifying a Poisson distribution ([see
-code](https://github.com/andrew-1234/sdm-usecase-master)).
+model specifying a Poisson distribution ([see code](https://github.com/andrew-1234/sdm-usecase-master)).
 
 ## Results
 
@@ -158,28 +155,36 @@ Owl which is only found in eastern Australia had relatively few locations where
 they were recorded. Chance resulted in more detections of Powerful Owl in
 southeast Queensland in observatory data, and that bias is reflected in attempts
 with multiple methods to predict their distribution using only observatory
-data.  Nonetheless, the presence-only model MaxEnt proved to be the best at
+data. Nonetheless, the presence-only model MaxEnt proved to be the best at
 approaching predictions of the actual distribution of Powerful Owl in eastern
-Australia (Figure 1).
+Australia (Figure 3).
+
+{{% figure src="./gg_powl_maxent_stack1_prediction.png" caption="Figure 3: " width="50%"%}}
 
 When comparing presence only data with presence / absence data, again results
 varied by species, but were most interesting for a species that had close to the
 same number of presence and absence data available, the Masked Owl. Using this
 owl's presence only data in a Bioclim model resulted in a reasonable
-approximation of geographic distribution in southern Australia (Figure 2).
+approximation of geographic distribution in southern Australia (Figure 4).
 However, that model completely failed to predict the presence of this owl in
 much of northern Australia. When presence absence data was run through a
 Artificial Neural Network model, the predictions included all of northern
-Australia (Figure 3) and were much more closely aligned to the known continental
+Australia (Figure 5) and were much more closely aligned to the known continental
 distribution of Masked Owl.
 
+{{% figure src="./maskedowl_BIOCLIM.png" caption="Figure 4: " width="50%"%}}
+
+{{% figure src="./maskedowl_ANN_w_absence_data.png" caption="Figure 5: " width="50%"%}}
+
 The mapped frequency of southern boobook suggests that it would be possible to
-predict areas where these owls call more (Figure 4). The results demonstrated
+predict areas where these owls call more (Figure 6). The results demonstrated
 some reasonable patterns, such as increased call frequency along what might be
 creeks or waterways in the outback, while the lowest call frequencies were in
 outback deserts. The high call frequency in SW WA also looked reasonable, but
 the lack of similar high call frequency areas in much of eastern Australia are
 likely due to insufficient sampling in this region.
+
+{{% figure src="./boobook_frequency.png" caption="Figure 6: " width="50%"%}}
 
 ## Discussion
 
@@ -198,10 +203,6 @@ modelled here, there were some stations that were fairly close together, and
 with fine resolution data it might be possible to tease apart the within cluster
 variation in presences or frequency of presences.
 
-As acoustic monitoring activities continue to grow we demonstrate how the
-absence data acoustic sensors can deliver and the call frequency can produce
-game changing results when looking to understand species distributions.
-
 It is well established that acoustic monitoring can provide significant
 ecological insights, across both broad spatial and temporal scales. As acoustic
 monitoring activities continue to grow, we demonstrate that when such data is
@@ -214,3 +215,10 @@ is further aided by the use of online platforms such as
 [EcoCommons](https://www.ecocommons.org.au/), which allows practitioners and
 researchers to seamlessly examine their data using a wide range of modelling
 tools and trusted datasets.
+
+If you would like to learn more about Species Distribution Modelling, you can
+visit the educational material sections of EcoCommons
+[here](https://www.ecocommons.org.au/educational-material/), and
+[here](https://support.ecocommons.org.au/support/solutions). For a wide range of
+resources, guides, and lessons relating to ecoacoustics, you can visit the
+[Resources]({{% ref "resources" %}}) section of this website.

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -113,7 +113,7 @@ The A2O uses a paired sensor design, with four sensors per site. The distance
 between sensors is typically within 500m to 5000m. Therefore, we first attempted
 to use environmental layers at a high spatial resolution (25m), to capture fine
 scale variation between proximate sensors.This came at a high computer
-processing cost. Even working with buffered extents, and using a Big Data PC,
+processing cost. Even working with buffered extents, and using a high-performance PC,
 the process was slow, highlighting the challenges of using such high resolution
 data. As a result, we decided to instead use a 250m resolution for preliminary
 analyses in R, and a 1000m resolution on the ecocommons platform. To get a

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -3,7 +3,7 @@ title: The Australian Acoustic Observatory, Hoot Detective, & the impact of good
 weight: 1
 ---
 
-By Dr Andrew Schwenke & Dr Rob Clemens
+By [Dr Andrew Schwenke](https://orcid.org/0000-0002-5281-0115) & [Dr Rob Clemens](https://orcid.org/0000-0002-1359-5133)
 
 ## Introduction
 
@@ -11,7 +11,7 @@ The Australian Acoustic Observatory (A2O) is a continental-scale acoustic sensor
 network that provides data for hundreds of acoustic sensors across seven
 Australian ecoregions. This data is freely available to researchers, citizen
 scientists, and the general public, for use under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) licence. More information
-about the A2O can be found in a paper published in [Methods in Ecology and Evolution (Roe at al., 2021)](https://acousticobservatory.org/wp-content/uploads/2021/07/A2O_Methods-in-Ecology-and-Evolution_2021.pdf).
+about the A2O can be found in a paper published in [Methods in Ecology and Evolution (Roe at al., 2021)](https://doi.org/10.1111/2041-210X.13660).
 For National Science Week in 2021, a partnership between ABC Science, the
 Australian Acoustic Observatory, Queensland University of Technology and the
 University of New England, formed the Hoot Detective project (Figure 1). This
@@ -50,16 +50,16 @@ use and evaluation. 
 
 Third, the field of species distribution modelling has thousands of papers
 related to using presence only modelling methods, or using binomial methods
-(presence / absence) with pseudo-absence data.  Pseudo absence data attempts to
+(presence / absence) with pseudo-absence data. Pseudo absence data attempts to
 make the best possible guess as to where species might be absent or at the least
 ensures that random pseudo-absence points are not selected in areas where there
-is zero chance that the species might be present.  As acoustic sensors are
+is zero chance that the species might be present. As acoustic sensors are
 increasingly deployed an understanding of detection probability begins to emerge
 for different sensors and different species. In other words, we can determine
 how long a sensor should be left out before we are nearly certain that the
 species of interest is not present. Once a sensor is left out the required
 amount of time, a true absence location is generated, and such data have
-explosive impacts on how well you can model species distributions using a
+significant impacts on how well you can model species distributions using a
 variety of both statistical and machine learning techniques.
 
 Fourth, an acoustic device records every single call a species makes near a
@@ -74,11 +74,13 @@ models are clear. For select species, an area with more calling might be more
 important for the species, and an area with more individuals calling might be
 relatively more important than the more silent areas.
 
-There are caveats around all of this of course, but below we demonstrate the
-kinds of results that can be generated with presence absence vs presence only
-data, and the insights that could be gained from predicting the spatial
-variation in call frequency.  We argue the benefits are clear, and ask you to
-help deliver this kind of data at scale.
+The advantages and assumptions discussed so far are likely to vary depending on
+the specific research question and species of interest. Nevertheless, the
+purpose of this use case is to demonstrate the kinds of results that can be
+generated with presence absence vs presence only data, and the insights that
+could be gained from predicting the spatial variation in call frequency.  We
+argue the benefits are clear, and ask you to help deliver this kind of data at
+scale.
 
 ## Methods
 
@@ -129,7 +131,7 @@ masked to the buffered boundary extent representing the known distribution. 
 
 Powerful Owl presence data were used to extract environmental variable values
 from eastern Australia, and the resulting presence data and environmental
-rasters were used in a Maxent model in R [(see code)](https://github.com/andrew-1234/sdm-usecase-master).
+rasters were used in a Maxent model in R [(see example code)](https://github.com/andrew-1234/sdm-usecase-master#maxent).
 
 Presence only vs presence absence comparisons were made within the EcoCommons
 platform. Evironmental predictors were at 1 km resolution and included the ANU
@@ -144,7 +146,7 @@ selected the Southern Boobook which was recorded at all but one station (mean
 137 vocalisations, range 0 to 993). We then extracted raster grid values from
 the two forest area variables, bioclim variables 5,6 and 17, and NVIS, a
 national vegetation classification. We then ran a Boosted regression tree (BRT)
-model specifying a Poisson distribution [(see code)](https://github.com/andrew-1234/sdm-usecase-master).
+model specifying a Poisson distribution [(see example code)](https://github.com/andrew-1234/sdm-usecase-master#brt).
 
 ## Results
 
@@ -215,3 +217,19 @@ is further aided by the use of online platforms such as
 [EcoCommons](https://www.ecocommons.org.au/), which allows practitioners and
 researchers to seamlessly examine their data using a wide range of modelling
 tools and trusted datasets.
+
+## Acknowledgements
+
+- We would like to first acknowledge the Australian Acoustic Observatory
+  [(A2O)](https://acousticobservatory.org/) and the Hoot Detective project, from
+  where recordings and annotations were sourced.
+- We would also like to acknowledge the
+  [EcoCommons](https://www.ecocommons.org.au/) platform for generating some of
+  the models used for this use case:
+  - To learn more about Species Distribution Modelling, you can visit the
+    EcoCommons support page section on
+  [SDMs](https://support.ecocommons.org.au/support/solutions/folders/6000240802).
+  - Visit the [Educational Material](https://www.ecocommons.org.au/educational-material/) section to
+  learn about using the EcoCommons modelling platform.
+  - Read more about ecoacoustic integration with EcoCommons
+    [here](https://www.ecocommons.org.au/acoustic-use-case/).

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -1,0 +1,4 @@
+---
+title: SDM
+weight: 1
+---

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -1,4 +1,216 @@
 ---
-title: SDM
+title: The Australian Acoustic Observatory, Hoot Detective, & the impact of good data on Species Distribution Models 
 weight: 1
 ---
+
+By Dr Andrew Schwenke & Dr Rob Clemens
+
+## Introduction
+
+The Australian Acoustic Observatory (A2O) is a continental-scale acoustic sensor
+network that provides data for hundreds of acoustic sensors across seven
+Australian ecoregions. This data is freely available to researchers, citizen
+scientists, and the general public, for use under [CC BY
+4.0](https://creativecommons.org/licenses/by/4.0/) licence. More information
+about the A2O can be found in a paper published in [Methods in Ecology and
+Evolution (Roe at al.,
+2021)](https://acousticobservatory.org/wp-content/uploads/2021/07/A2O_Methods-in-Ecology-and-Evolution_2021.pdf).
+For National Science Week in 2021, a partnership between ABC Science, the
+Australian Acoustic Observatory, Queensland University of Technology and the
+University of New England, formed the Hoot Detective project. This was a citizen
+science project that used recordings from the Australian Acoustic Observatory,
+resulting in the identification of 23,568 owl calls by members of the public.
+There are a variety of advantages to this kind of continental scale data
+([Guerin et al.
+2020](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecs2.3307))
+and those advantages directly apply to questions looking to predict a species
+distribution.
+
+First, occurrence data for most fauna in Australia are not systematically
+collected at geographic scales. Most data for species that vocalise are highly
+biased with the most sampling done near the handful of urban areas in what is
+otherwise the remote continent of Australia. Dealing with sampling bias in
+species distribution modelling is one of the biggest challenges to generating
+optimal results. However, these sampling issues can be virtually eliminated by
+deploying ecoacoustic sensors based on sampling protocols that are
+representative of both geographic and environmental space. The Australian
+Acoustic Observatory achieves this at a continental scale, with around 360
+continuously operating acoustic sensors deployed across Australia in a variety
+of unique ecosystems. 
+
+Second, while there will always be variation in detection probability in any
+fauna survey, ecoacoustic data takes a huge leap toward delivering standardised
+data. In species distribution modelling, the complications arising from variable
+detection rates have led many researchers to model detection, using something
+called occupancy modelling. Indeed, occupancy modelling may be helpful when
+accounting for variable detection rates between sites and sensors when working
+with acoustic data. But when using acoustic sensors, survey effort is much more
+standardised than in human observation data, which can reduce or eliminate the
+need to use such techniques. Furthermore, species identifications from
+ecoacoustic data are verifiable and can exist as a persistent record for future
+use and evaluation. 
+
+Third, the field of species distribution modelling has thousands of papers
+related to using presence only modelling methods, or using binomial methods
+(presence / absence) with pseudo-absence data.  Pseudo absence data attempts to
+make the best possible guess as to where species might be absent or at the least
+ensures that random pseudo-absence points are not selected in areas where there
+is zero chance that the species might be present.  As acoustic sensors are
+increasingly deployed an understanding of detection probability begins to emerge
+for different sensors and different species. In other words, we can determine
+how long a sensor should be left out before we are nearly certain that the
+species of interest is not present. Once a sensor is left out the required
+amount of time, a true absence location is generated, and such data have
+explosive impacts on how well you can model species distributions using a
+variety of both statistical and machine learning techniques.
+
+Fourth, an acoustic device records every single call a species makes near a
+monitor. While human observation data can also provide such data, it would be a
+massive undertaking to deliver that kind of data at scale. Yet, for many species
+that vocalise, one can expect call rates to be highest in areas and times of
+year when species are breeding, and vocalisation rates may even be higher in
+areas of higher quality habitat (at least for some species). Modelling the
+distribution of call frequency or abundance has been done far less in the
+literature than presence only modelling, yet the potential insights from such
+models are clear. For select species, an area with more calling might be more
+important for the species, and an area with more individuals calling might be
+relatively more important than the more silent areas.
+
+There are caveats around all of this of course, but below we demonstrate the
+kinds of results that can be generated with presence absence vs presence only
+data, and the insights that could be gained from predicting the spatial
+variation in call frequency.  We argue the benefits are clear, and ask you to
+help deliver this kind of data at scale.
+
+## Methods
+
+The data were obtained from the historical Hoot Detective project, and consisted
+of annotations for five owl species: Masked Owl (Tyto novaehollandiae), Eastern
+Barn Owl (Tyto javanica), Barking Owl (Ninox connivens), Powerful Owl (Ninox
+strenua), and Southern Boobook (Ninox boobook). All data, including audio
+recordings, annotations, and associated sensor metadata, is available for
+download and use from the [A2O data
+portal](https://acousticobservatory.org/data/find-data/). A GitHub repository
+detailing the complete methods for preparing the Hoot Detective data, prediction
+layers, and running preliminary SDM analyses with R is
+[available](https://github.com/andrew-1234/sdm-usecase-master).
+
+### Data preparation
+
+The Hoot Detective project resulted in 28723 segments of annotated audio, from
+37 sensors. Each segment of audio was 10 seconds in length, resulting in a total
+of just under 80 hours of annotated audio. Audio segments came from most days
+spanning between June, 2019, until July, 2021 (Figure XX). These annotations
+were summarised in R to get occurrence data for each species, which included
+determining if at any point the target species was recorded (presence) or was
+absent from recordings (absence). 
+
+A Powerful Owl presence was recorded in Western Australia, which is quite far
+outside of the recognised distribution. Therefore, Powerful Owl records were
+filtered further, using a buffered boundary of the known distribution extent
+derived from ALA records (?), to remove these potentially anomalous records. 
+
+The A2O uses a paired sensor design, with four sensors per site. The distance
+between sensors is typically within 500m to 5000m. Therefore, we first attempted
+to use environmental layers at a high spatial resolution (25m), to capture fine
+scale variation between proximate sensors.This came at a high computer
+processing cost. Even working with buffered extents, and using a Big Data PC,
+the process was slow, highlighting the challenges of using such high resolution
+data. As a result, we decided to instead use a 250m resolution for preliminary
+analyses in R, and a 1000m resolution on the ecocommons platform. To get a
+raster stack for the extent of Australia, the terra package in R was used to
+crop and mask layers to a vector of the Australian boundary. Layers were then
+resampled from their original resolution where necessary to 250m, using bilinear
+interpolation for continuous bioclim data, mean for forest canopy and height,
+and nearest neighbour for categorical data. All layers were projected to the
+project CRS (EPSG: 4326). For Powerful Owl, the raster stack was cropped and
+masked to the buffered boundary extent representing the known distribution. 
+
+### Analysis
+
+Powerful Owl presence data were used to extract environmental variable values
+from eastern Australia, and the resulting presence data and environmental
+rasters were used in a Maxent model in R ([see
+code](https://github.com/andrew-1234/sdm-usecase-master)).
+
+Presence only vs presence absence comparisons were made within the EcoCommons
+platform. Evironmental predictors were at 1 km resolution and included the ANU
+Bioclim variables, 5,6,13 & 17, run in BioClim and SRE for presence only, and
+ANN, RF, & MARS.  First, the presence only occurrence records were used to
+generate a BioClim model prediction using default settings. Then the presence
+absence data were used in an Artificial Neural Network (ANN) model, Random
+Forest model, and multivariate adaptive regression splines (MARS).
+
+To examine the potential of predicting call frequency across Australia we
+selected the Southern Boobook which was recorded at all but one station (mean
+137 vocalisations, range 0 to 993). We then extracted raster grid values from
+the two forest area variables, bioclim variables 5,6 and 17, and NVIS, a
+national vegetation classification. We then ran a Boosted regression tree (BRT)
+model specifying a Poisson distribution ([see
+code](https://github.com/andrew-1234/sdm-usecase-master)).
+
+## Results
+
+The 37 monitoring stations that were included in the Hoot Detective project are
+spread across large areas of Australia, so it is perhaps not surprising that
+data availability and results varied between species. For example, the Powerful
+Owl which is only found in eastern Australia had relatively few locations where
+they were recorded. Chance resulted in more detections of Powerful Owl in
+southeast Queensland in observatory data, and that bias is reflected in attempts
+with multiple methods to predict their distribution using only observatory
+data.  Nonetheless, the presence-only model MaxEnt proved to be the best at
+approaching predictions of the actual distribution of Powerful Owl in eastern
+Australia (Figure 1).
+
+When comparing presence only data with presence / absence data, again results
+varied by species, but were most interesting for a species that had close to the
+same number of presence and absence data available, the Masked Owl. Using this
+owl's presence only data in a Bioclim model resulted in a reasonable
+approximation of geographic distribution in southern Australia (Figure 2).
+However, that model completely failed to predict the presence of this owl in
+much of northern Australia. When presence absence data was run through a
+Artificial Neural Network model, the predictions included all of northern
+Australia (Figure 3) and were much more closely aligned to the known continental
+distribution of Masked Owl.
+
+The mapped frequency of southern boobook suggests that it would be possible to
+predict areas where these owls call more (Figure 4). The results demonstrated
+some reasonable patterns, such as increased call frequency along what might be
+creeks or waterways in the outback, while the lowest call frequencies were in
+outback deserts. The high call frequency in SW WA also looked reasonable, but
+the lack of similar high call frequency areas in much of eastern Australia are
+likely due to insufficient sampling in this region.
+
+## Discussion
+
+It was surprising how well some of the data predicted continental distributions
+despite there being relatively few records available (< 37 for each species).
+It was also striking how vastly different predictions were when using presence
+only vs presence absence data. Finally, the variation in predicted call
+frequency of the southern Boobook across Australia suggests that the metric of
+call frequency may be a useful indicator of habitats that get more use,
+potentially related to habitat quality or breeding activity.
+
+Initial attempts to model with 25m resolution proved too much to data to handle,
+but further work to tile data extractions and predictions would likely allow
+such high resolution predictions, and while not useful at the continental scale
+modelled here, there were some stations that were fairly close together, and
+with fine resolution data it might be possible to tease apart the within cluster
+variation in presences or frequency of presences.
+
+As acoustic monitoring activities continue to grow we demonstrate how the
+absence data acoustic sensors can deliver and the call frequency can produce
+game changing results when looking to understand species distributions.
+
+It is well established that acoustic monitoring can provide significant
+ecological insights, across both broad spatial and temporal scales. As acoustic
+monitoring activities continue to grow, we demonstrate that when such data is
+annotated, whether by using
+[recognisers](https://openecoacoustics.org/resources/registry/), or through
+citizen science projects such as Hoot Detective, the absence data acoustic
+sensors can deliver and the call frequency metric provided, can produce game
+changing results when looking to understand species distributions. This process
+is further aided by the use of online platforms such as
+[EcoCommons](https://www.ecocommons.org.au/), which allows practitioners and
+researchers to seamlessly examine their data using a wide range of modelling
+tools and trusted datasets.

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -221,8 +221,8 @@ tools and trusted datasets.
 ## Acknowledgements
 
 - We would like to first acknowledge the Australian Acoustic Observatory
-  [(A2O)](https://acousticobservatory.org/) and the Hoot Detective project, from
-  where recordings and annotations were sourced.
+  [(A2O)](https://acousticobservatory.org/) for the recording data.
+- The Hoot Detective project for providing the annotations.
 - We would also like to acknowledge the
   [EcoCommons](https://www.ecocommons.org.au/) platform for generating some of
   the models used for this use case:

--- a/content/resources/use-cases/sdm/index.md
+++ b/content/resources/use-cases/sdm/index.md
@@ -18,7 +18,7 @@ University of New England, formed the Hoot Detective project (Figure 1). This
 was a citizen science project that used recordings from the Australian Acoustic
 Observatory, resulting in the identification of 23,568 owl calls by members of
 the public. There are a variety of advantages to this kind of continental scale
-data ([Guerin et al. 2020](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecs2.3307))
+data [(Guerin et al. 2020)](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1002/ecs2.3307)
 and those advantages directly apply to questions looking to predict a species
 distribution.
 
@@ -129,7 +129,7 @@ masked to the buffered boundary extent representing the known distribution. 
 
 Powerful Owl presence data were used to extract environmental variable values
 from eastern Australia, and the resulting presence data and environmental
-rasters were used in a Maxent model in R ([see code](https://github.com/andrew-1234/sdm-usecase-master)).
+rasters were used in a Maxent model in R [(see code)](https://github.com/andrew-1234/sdm-usecase-master).
 
 Presence only vs presence absence comparisons were made within the EcoCommons
 platform. Evironmental predictors were at 1 km resolution and included the ANU
@@ -144,7 +144,7 @@ selected the Southern Boobook which was recorded at all but one station (mean
 137 vocalisations, range 0 to 993). We then extracted raster grid values from
 the two forest area variables, bioclim variables 5,6 and 17, and NVIS, a
 national vegetation classification. We then ran a Boosted regression tree (BRT)
-model specifying a Poisson distribution ([see code](https://github.com/andrew-1234/sdm-usecase-master)).
+model specifying a Poisson distribution [(see code)](https://github.com/andrew-1234/sdm-usecase-master).
 
 ## Results
 
@@ -159,7 +159,7 @@ data. Nonetheless, the presence-only model MaxEnt proved to be the best at
 approaching predictions of the actual distribution of Powerful Owl in eastern
 Australia (Figure 3).
 
-{{% figure src="./gg_powl_maxent_stack1_prediction.png" caption="Figure 3: " width="50%"%}}
+{{% figure src="./gg_powl_maxent_stack1_prediction.png" caption="Figure 3: MaxEnt prediction of environmental suitability using Powerful Owl prescence data and five environmental layers. Prescenes are marked with blue circles (note that some records are overlapping due to the scale)." width="100%"%}}
 
 When comparing presence only data with presence / absence data, again results
 varied by species, but were most interesting for a species that had close to the
@@ -172,11 +172,11 @@ Artificial Neural Network model, the predictions included all of northern
 Australia (Figure 5) and were much more closely aligned to the known continental
 distribution of Masked Owl.
 
-{{% figure src="./maskedowl_BIOCLIM.png" caption="Figure 4: " width="50%"%}}
+{{% figure src="./maskedowl_BIOCLIM.png" caption="Figure 4: Masked Owl distribution prediction using a Bioclim model (presence only), generated on the EcoCommons platform." width="50%"%}}
 
-{{% figure src="./maskedowl_ANN_w_absence_data.png" caption="Figure 5: " width="50%"%}}
+{{% figure src="./maskedowl_ANN_w_absence_data.png" caption="Figure 5: Masked Owl distribution prediction using a Artificial Neural Network model (presence / absence data), generated on the EcoCommons platform." width="50%"%}}
 
-The mapped frequency of southern boobook suggests that it would be possible to
+The mapped frequency of Southern Boobook suggests that it would be possible to
 predict areas where these owls call more (Figure 6). The results demonstrated
 some reasonable patterns, such as increased call frequency along what might be
 creeks or waterways in the outback, while the lowest call frequencies were in
@@ -184,7 +184,7 @@ outback deserts. The high call frequency in SW WA also looked reasonable, but
 the lack of similar high call frequency areas in much of eastern Australia are
 likely due to insufficient sampling in this region.
 
-{{% figure src="./boobook_frequency.png" caption="Figure 6: " width="50%"%}}
+{{% figure src="./boobook_frequency.png" caption="Figure 6: Predicted call frequency (number of calls) of the Southern Boobook, using a Boosted Regression Tree." width="100%"%}}
 
 ## Discussion
 
@@ -192,16 +192,16 @@ It was surprising how well some of the data predicted continental distributions
 despite there being relatively few records available (< 37 for each species).
 It was also striking how vastly different predictions were when using presence
 only vs presence absence data. Finally, the variation in predicted call
-frequency of the southern Boobook across Australia suggests that the metric of
+frequency of the Southern Boobook across Australia suggests that the metric of
 call frequency may be a useful indicator of habitats that get more use,
 potentially related to habitat quality or breeding activity.
 
-Initial attempts to model with 25m resolution proved too much to data to handle,
-but further work to tile data extractions and predictions would likely allow
-such high resolution predictions, and while not useful at the continental scale
-modelled here, there were some stations that were fairly close together, and
-with fine resolution data it might be possible to tease apart the within cluster
-variation in presences or frequency of presences.
+Initial attempts to model with 25m resolution proved to be too much data to
+handle, but further work to tile data extractions and predictions would likely
+allow such high resolution predictions, and while not useful at the continental
+scale modelled here, there were some stations that were fairly close together,
+and with fine resolution data it might be possible to tease apart the within
+cluster variation in presences or frequency of presences.
 
 It is well established that acoustic monitoring can provide significant
 ecological insights, across both broad spatial and temporal scales. As acoustic
@@ -215,10 +215,3 @@ is further aided by the use of online platforms such as
 [EcoCommons](https://www.ecocommons.org.au/), which allows practitioners and
 researchers to seamlessly examine their data using a wide range of modelling
 tools and trusted datasets.
-
-If you would like to learn more about Species Distribution Modelling, you can
-visit the educational material sections of EcoCommons
-[here](https://www.ecocommons.org.au/educational-material/), and
-[here](https://support.ecocommons.org.au/support/solutions). For a wide range of
-resources, guides, and lessons relating to ecoacoustics, you can visit the
-[Resources]({{% ref "resources" %}}) section of this website.

--- a/content/resources/use-cases/sdm/maskedowl_ANN_w_absence_data.png
+++ b/content/resources/use-cases/sdm/maskedowl_ANN_w_absence_data.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20d34f3abbe64c25c95d1f12b772f239cb1d71ba54eaf9535148ca080dfc67d4
+size 1243281

--- a/content/resources/use-cases/sdm/maskedowl_BIOCLIM.png
+++ b/content/resources/use-cases/sdm/maskedowl_BIOCLIM.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04ed3a9b644e9658f7ee2b93e3e9b82c6f7e7fddab8eb7d5b39929d93a053881
+size 147174


### PR DESCRIPTION
- This branch adds a new section under resources titled Use Cases for Ecoacoustics
- This is a section to showcase the utility of ecoacoustic data in the form of "use cases":
  - Use cases can be a demonstration of analysis methods, workflows, results etc, and are formatted in the style of a (more informal) scientific report
  - The goal is to demonstrate the advantages of using passive acoustic data to examine a range of different research questions, and highlight the various analysis methods that are available
- Currently this includes two use cases: /sdm and /gdm
