### PR TITLE
Fix mobile overflow for non-wrapping blog elements

### DIFF
--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -5,6 +5,7 @@
     flex-direction: column;
 
     min-height: 100%;
+    max-width: 100%;
 }
 
 .page-hero {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -89,6 +89,7 @@
     align-content: center;
     align-self: center;
     background-color: var(--oe-background-color);
+    max-width: 100%;
 
     &-breadcrumb {
         margin-top: var(--oe-padding-smaller);


### PR DESCRIPTION
This commit restricts the `.page` and `.oe-post` width to the size of the theming container.

Meaning that content that does not wrap and cannot scale (e.g. `<pre>` elements) now overflow with scroll bars instead of expanding the website width.

This is not a permanent fix as I suspect that the `.container` not constraining its child elements is a smell that there's some underlying issue.