### PR TITLE
fix: Hard lock preact and htm cdn versions

### DIFF
--- a/assets/js/preact-common.js
+++ b/assets/js/preact-common.js
@@ -1,20 +1,24 @@
 // https://github.com/preactjs/preact/issues/1961
 //import "https://cdn.skypack.dev/preact/debug";
+//
+// we hard lock preact versions and do not allow minor version bumps because
+// the preact skypack deployment has broken between minor versions before
+// see: https://github.com/ecoacoustics/website/issues/114
 import {
     h,
     Component,
     render,
     createRef,
-} from "https://cdn.skypack.dev/preact";
+} from "https://cdn.skypack.dev/preact@10.26.4";
 import {
     useState,
     useEffect,
     useCallback,
     useReducer,
     useMemo,
-} from "https://cdn.skypack.dev/preact/hooks";
+} from "https://cdn.skypack.dev/preact/hooks@10.26.4";
 
-import htm from "https://cdn.skypack.dev/htm";
+import htm from "https://cdn.skypack.dev/htm@3.1.1";
 
 // Initialize htm with Preact
 const html = htm.bind(h);


### PR DESCRIPTION
# fix: Hard lock preact and htm cdn versions

We never used to hard lock preact and htm versions fetched from the cdn, meaning that the dependency would automatically update in the production environment.

This caused issues when a minor version bump caused the skypack cdn builds to fail, causing preact pages to break.

This commit also reduces our attack surface for supply chain attacks.

Fixes: #114